### PR TITLE
Add jump to the include file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 keywords/feeders*
 .vscode
 .vscode/settings.json
+node_modules/
+out/

--- a/language-configuration-lspp-cfile.json
+++ b/language-configuration-lspp-cfile.json
@@ -1,0 +1,5 @@
+{
+    "comments": {
+        "lineComment": "$"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,56 @@
+{
+    "name": "lsdyna",
+    "version": "1.2.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lsdyna",
+            "version": "1.2.1",
+            "license": "SEE LICENSE IN LICENSE",
+            "dependencies": {
+                "typescript": "^5.8.2"
+            },
+            "devDependencies": {
+                "@types/node": "^22.13.11",
+                "@types/vscode": "^1.30.0"
+            },
+            "engines": {
+                "vscode": "^1.30.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "22.13.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+            "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.98.0.tgz",
+            "integrity": "sha512-+KuiWhpbKBaG2egF+51KjbGWatTH5BbmWQjSLMDCssb4xF8FJnW4nGH4nuAdOOfMbpD0QlHtI+C3tPq+DoKElg==",
+            "dev": true
+        },
+        "node_modules/typescript": {
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "Programming Languages"
     ],
     "activationEvents": [
-        "onCommand:extension.jumpToInclude"
+        "onCommand:extension.openIncludeFile"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -52,14 +52,14 @@
         ],
         "commands": [
             {
-                "command": "extension.jumpToInclude",
-                "title": "Jump to *INCLUDE File"
+                "command": "extension.openIncludeFile",
+                "title": "Open *INCLUDE File"
             }
         ],
         "menus": {
             "editor/context": [
                 {
-                    "command": "extension.jumpToInclude",
+                    "command": "extension.openIncludeFile",
                     "when": "editorLangId == 'lsdyna'",
                     "group": "navigation"
                 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "Programming Languages"
     ],
     "activationEvents": [
-        "onCommand:extension.openIncludeFile"
+        "onCommand:extension.openIncludeFile",
+        "onCommand:extension.selectKeyword"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -54,6 +55,10 @@
             {
                 "command": "extension.openIncludeFile",
                 "title": "Open *INCLUDE File"
+            },
+            {
+                "command": "extension.selectKeyword",
+                "title": "Select Current Keyword"
             }
         ],
         "menus": {
@@ -62,6 +67,11 @@
                     "command": "extension.openIncludeFile",
                     "when": "editorLangId == 'lsdyna'",
                     "group": "navigation"
+                },
+                {
+                    "command": "extension.selectKeyword",
+                    "when": "editorLangId == 'lsdyna'",
+                    "group": "9_cutcopypaste"
                 }
             ]
         }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "categories": [
         "Programming Languages"
     ],
+    "activationEvents": [
+        "onCommand:extension.jumpToInclude"
+    ],
+    "main": "./out/extension.js",
     "contributes": {
         "languages": [
             {
@@ -45,7 +49,22 @@
                 "language": "lsdyna",
                 "path": "./snippets/lsdyna.json"
             }
-        ]
+        ],
+        "commands": [
+            {
+                "command": "extension.jumpToInclude",
+                "title": "Jump to *INCLUDE File"
+            }
+        ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "extension.jumpToInclude",
+                    "when": "editorLangId == 'lsdyna'",
+                    "group": "navigation"
+                }
+            ]
+        }
     },
     "release": {
         "branches": "master",
@@ -61,5 +80,12 @@
         "fail": [
             "@semantic-release/github"
         ]
+    },
+    "dependencies": {
+        "typescript": "^5.8.2"
+    },
+    "devDependencies": {
+        "@types/node": "^22.13.11",
+        "@types/vscode": "^1.30.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     ],
     "activationEvents": [
         "onCommand:extension.openIncludeFile",
-        "onCommand:extension.selectKeyword"
+        "onCommand:extension.selectKeyword",
+        "onCommand:extension.jumpToNextKeyword",
+        "onCommand:extension.jumpToPreviousKeyword"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -59,6 +61,28 @@
             {
                 "command": "extension.selectKeyword",
                 "title": "Select Current Keyword"
+            },
+            {
+                "command": "extension.jumpToNextKeyword",
+                "title": "Jump to Next Keyword",
+                "icon": "$(arrow-down)"
+            },
+            {
+                "command": "extension.jumpToPreviousKeyword",
+                "title": "Jump to Previous Keyword",
+                "icon": "$(arrow-up)"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "extension.jumpToNextKeyword",
+                "key": "ctrl+alt+down",
+                "when": "editorLangId == 'lsdyna'"
+            },
+            {
+                "command": "extension.jumpToPreviousKeyword",
+                "key": "ctrl+alt+up",
+                "when": "editorLangId == 'lsdyna'"
             }
         ],
         "menus": {
@@ -72,6 +96,18 @@
                     "command": "extension.selectKeyword",
                     "when": "editorLangId == 'lsdyna'",
                     "group": "9_cutcopypaste"
+                }
+            ],
+            "editor/title": [
+                {
+                    "command": "extension.jumpToNextKeyword",
+                    "when": "editorLangId == 'lsdyna'",
+                    "group": "navigation"
+                },
+                {
+                    "command": "extension.jumpToPreviousKeyword",
+                    "when": "editorLangId == 'lsdyna'",
+                    "group": "navigation"
                 }
             ]
         }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,17 @@
                     ".dyna"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "lsprepost-command-file",
+                "aliases": [
+                    "LS-PrePost Command File",
+                    "LS-PrePost cfile"
+                ],
+                "extensions": [
+                    ".cfile"
+                ],
+                "configuration": "./language-configuration-lspp-cfile.json"
             }
         ],
         "grammars": [
@@ -38,6 +49,11 @@
                 "language": "lsdyna",
                 "scopeName": "source.lsdyna",
                 "path": "./syntaxes/lsdyna.tmLanguage.json"
+            },
+            {
+                "language": "lsprepost-command-file",
+                "scopeName": "source.lsprepost-command-file",
+                "path": "./syntaxes/lspp-cfile.tmLanguage.json"
             }
         ],
         "snippets": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,60 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    let jumpToNextKeywordDisposable = vscode.commands.registerCommand('extension.jumpToNextKeyword', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        const document = editor.document;
+        const lines = document.getText().split('\n');
+        const currentLineIndex = editor.selection.active.line;
+
+        try {
+            const nextLine = findNextKeyword(lines, currentLineIndex);
+
+            const position = new vscode.Position(nextLine, 0);
+            editor.selection = new vscode.Selection(position, position);
+            editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`${error.message}`);
+            } else {
+                throw error;
+            }
+        }
+    });
+
+    let jumpToPreviousKeywordDisposable = vscode.commands.registerCommand('extension.jumpToPreviousKeyword', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        const document = editor.document;
+        const lines = document.getText().split('\n');
+        const currentLineIndex = editor.selection.active.line;
+
+        try {
+            const prevLine = findPreviousKeyword(lines, currentLineIndex);
+
+            const position = new vscode.Position(prevLine, 0);
+            editor.selection = new vscode.Selection(position, position);
+            editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`${error.message}`);
+            } else {
+                throw error;
+            }
+        }
+    });
+
     context.subscriptions.push(openIncludeFileDisposable);
     context.subscriptions.push(selectKeywordDisposable);
+    context.subscriptions.push(jumpToNextKeywordDisposable);
+    context.subscriptions.push(jumpToPreviousKeywordDisposable);
 }
 
 /**
@@ -210,6 +262,36 @@ function searchFileFromPaths(filePath: string, paths: string[]) {
         }
     }
     throw new Error(`${filePath} not found`);
+}
+
+/**
+ * Finds the next keyword line by searching downwards
+ * @param lines Array of document lines
+ * @param currentLine Current line index
+ * @returns Line index of the next keyword
+ */
+function findNextKeyword(lines: string[], currentLine: number) {
+    for(let i=currentLine+1; i<lines.length; i++){
+        if (lines[i].startsWith("*")){
+            return i;
+        }
+    }
+    throw new Error('No more keywords found.');
+}
+
+/**
+ * Finds the previous keyword line by searching upwards
+ * @param lines Array of document lines
+ * @param currentLine Current line index
+ * @returns Line index of the previous keyword
+ */
+function findPreviousKeyword(lines: string[], currentLine: number) {
+    for(let i=currentLine-1; i>=0; i--){
+        if (lines[i].startsWith("*")){
+            return i;
+        }
+    }
+    throw new Error('No previous keywords found.');
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,173 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export function activate(context: vscode.ExtensionContext) {
+    let disposable = vscode.commands.registerCommand('extension.jumpToInclude', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        const document = editor.document;
+        const lines = document.getText().split('\n');
+        const currentLineIndex = editor.selection.active.line;
+
+        try {
+            // get Full Path
+            const paths = getSearchPath(document);
+            const fileName = getFilenameFromKeyword(lines, currentLineIndex);
+            const fullPath = searchFileFromPaths(fileName, paths);
+
+            // Jump to File
+            vscode.workspace.openTextDocument(fullPath).then(doc => {
+                vscode.window.showTextDocument(doc);
+            });
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`${error.message}`);
+            } else {
+                throw error;
+            }
+        }
+    });
+
+    context.subscriptions.push(disposable);
+}
+
+/**
+ * Gets the search paths for include files
+ * First path is always the directory of the current file
+ * Additional paths are extracted from *INCLUDE_PATH and *INCLUDE_PATH_RELATIVE keywords
+ * @param document Current text document
+ * @returns Array of search paths
+ */
+function getSearchPath(document: vscode.TextDocument) {
+    const textPath = path.dirname(document.uri.fsPath);
+    let paths = [textPath];
+
+    const lines = document.getText().split('\n');
+    let keyword = "";
+    for(let i=0; i<lines.length; i++){
+        if (lines[i].startsWith("$")){
+            continue;
+        }
+        if (lines[i].startsWith("*")){
+            keyword = lines[i].trim();
+            continue;
+        }
+        if (keyword=="*INCLUDE_PATH"){
+            paths.push(lines[i].trim());
+
+        }else if (keyword=="*INCLUDE_PATH_RELATIVE"){
+            paths.push(path.resolve(textPath, lines[i].trim()));
+        }
+    }
+    return paths;
+}
+
+/**
+ * Extracts the filename from the current keyword based on keyword type
+ * Supports different types of INCLUDE keywords with varying file location cards
+ * @param lines Array of document lines
+ * @param lineindex Current line index
+ * @returns Filename string
+ */
+function getFilenameFromKeyword(lines: string[], lineindex: number) {
+    const linestart = startLineOfCurrentKeyword(lines, lineindex);
+    const keyword = lines[linestart].trim();
+
+    if (keyword == "*INCLUDE") {
+        return getFilenameFromCurrentCard(lines, lineindex);
+
+    } else if (keyword.startsWith("*INCLUDE_PATH")) {
+        throw new Error("This keyword does not have filename card.");
+
+    } else if (keyword.startsWith("*INCLUDE_MULTISCALE_SPOTWELD")) {
+        return getFileNameFromNthCard(lines, linestart, 2);
+
+    } else if (keyword.startsWith("*INCLUDE")) {
+        return getFileNameFromNthCard(lines, linestart, 1);
+
+    } else {
+        throw new Error("This keyword is not supported.");
+    }
+}
+
+/**
+ * Finds the starting line of the current keyword by searching upwards
+ * @param lines Array of document lines
+ * @param lineindex Current line index
+ * @returns Line index where the current keyword starts
+ */
+function startLineOfCurrentKeyword(lines: string[], lineindex: number) {
+    for(let i=lineindex; i>=0; i--){
+        if (lines[i].startsWith("*")){
+            return i;
+        }
+    }
+    throw new Error('not on any keyword.');
+}
+
+/**
+ * Gets filename from the card where the cursor is currently positioned
+ * Skips comment lines starting with '$'
+ * @param lines Array of document lines
+ * @param lineindex Current line index
+ * @returns Filename string from the current card
+ */
+function getFilenameFromCurrentCard(lines: string[], lineindex: number) {
+    if (lines[lineindex].startsWith("*")) {
+        // Cursor on keyword line
+        lineindex++;
+    }
+    while(!lines[lineindex].startsWith("*")){
+        if (lines[lineindex].startsWith("$")){
+            lineindex++;
+            continue;
+        }
+        return lines[lineindex].trim();
+    }
+    throw new Error('No file to jump to.');
+}
+
+/**
+ * Gets filename from the nth card of the current keyword
+ * Skips comment lines starting with '$'
+ * @param lines Array of document lines
+ * @param lineindex Start line index of the keyword
+ * @param nth Card number to read filename from
+ * @returns Filename string from the specified card
+ */
+function getFileNameFromNthCard(lines: string[], lineindex: number, nth: number) {
+    let card = 1;
+    for(let i=lineindex+1; !lines[i].startsWith("*"); i++){
+        if (lines[i].startsWith("$")){
+            continue;
+        }
+        if (card==nth) {
+            return lines[i].trim();
+        }
+        card++;
+    }
+    throw new Error('No file to jump to.');
+}
+
+/**
+ * Searches for a file in the given paths
+ * Returns the first matching full path found
+ * @param filePath Filename to search for
+ * @param paths Array of directories to search in
+ * @returns Full path of the found file
+ */
+function searchFileFromPaths(filePath: string, paths: string[]) {
+    for (let i = 0; i < paths.length; i++) {
+        const fullPath = path.resolve(paths[i], filePath);
+        if (fs.existsSync(fullPath)) {
+            return fullPath;
+        }
+    }
+    throw new Error(`${filePath} not found`);
+}
+
+export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(selectKeywordDisposable);
     context.subscriptions.push(jumpToNextKeywordDisposable);
     context.subscriptions.push(jumpToPreviousKeywordDisposable);
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSymbolProvider(
+            { language: 'lsdyna' },
+            new LsdynaKeywordSymbolProvider()
+        )
+    );
 }
 
 /**
@@ -292,6 +298,35 @@ function findPreviousKeyword(lines: string[], currentLine: number) {
         }
     }
     throw new Error('No previous keywords found.');
+}
+
+/**
+ * Provides document symbols for LS-DYNA keywords
+ * @implements DocumentSymbolProvider
+ */
+class LsdynaKeywordSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+        const symbols: vscode.DocumentSymbol[] = [];
+        for (let i = 0; i < document.lineCount; i++) {
+            const line = document.lineAt(i);
+            if (line.text.startsWith('*')) {
+                const name = line.text.trim();
+                symbols.push(
+                    new vscode.DocumentSymbol(
+                        name,
+                        '',
+                        vscode.SymbolKind.Property,
+                        line.range,
+                        line.range
+                    )
+                );
+            }
+        }
+        return symbols;
+    }
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
-    let disposable = vscode.commands.registerCommand('extension.jumpToInclude', () => {
+    let openIncludeFileDisposable = vscode.commands.registerCommand('extension.openIncludeFile', () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             return;
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(disposable);
+    context.subscriptions.push(openIncludeFileDisposable);
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,34 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    let selectKeywordDisposable = vscode.commands.registerCommand('extension.selectKeyword', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
+        }
+
+        const document = editor.document;
+        const lines = document.getText().split('\n');
+        const currentLineIndex = editor.selection.active.line;
+
+        try {
+            const startLine = startLineOfCurrentKeyword(lines, currentLineIndex);
+            const endLine = endLineOfCurrentKeyword(lines, currentLineIndex);
+
+            const startPosition = new vscode.Position(startLine, 0);
+            const endPosition = new vscode.Position(endLine + 1, 0);
+            editor.selection = new vscode.Selection(startPosition, endPosition);
+        } catch (error) {
+            if (error instanceof Error) {
+                vscode.window.showErrorMessage(`${error.message}`);
+            } else {
+                throw error;
+            }
+        }
+    });
+
     context.subscriptions.push(openIncludeFileDisposable);
+    context.subscriptions.push(selectKeywordDisposable);
 }
 
 /**
@@ -107,6 +134,21 @@ function startLineOfCurrentKeyword(lines: string[], lineindex: number) {
         }
     }
     throw new Error('not on any keyword.');
+}
+
+/**
+ * Finds the ending line of the current keyword by searching downwards
+ * @param lines Array of document lines
+ * @param lineindex Current line index
+ * @returns Line index where the current keyword ends
+ */
+function endLineOfCurrentKeyword(lines: string[], lineindex: number) {
+    for(let i=lineindex+1; i<lines.length; i++){
+        if (lines[i].startsWith("*")){
+            return i-1;
+        }
+    }
+    return lines.length-1;
 }
 
 /**

--- a/syntaxes/lspp-cfile.tmLanguage.json
+++ b/syntaxes/lspp-cfile.tmLanguage.json
@@ -1,0 +1,85 @@
+{
+    "name": "LS-PrePost Command File",
+    "scopeName": "source.lsprepost-command-file",
+    "fileTypes": ["cfile"],
+    "patterns": [
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "include": "#constants"
+        },
+        {
+            "include": "#parameters"
+        },
+        {
+            "include": "#parameter-references"
+        },
+        {
+            "include": "#statements"
+        }
+    ],
+    "repository": {
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.dollar.lsprepost-command-file",
+                    "match": "\\$.*$"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "name": "string.quoted.double.lsprepost-command-file",
+                    "begin": "\"",
+                    "end": "\"|\\n",
+                    "patterns": [
+                        {
+                            "include": "#parameter-references"
+                        }
+                    ]
+                }
+            ]
+        },
+        "constants": {
+            "patterns": [
+                {
+                    "name": "constant.numeric.lsprepost-command-file",
+                    "match": "\\b[+-]?(\\d+|\\d*\\.?\\d+)(?:[eE][-+]?\\d+)?\\b"
+                }
+            ]
+        },
+        "parameters": {
+            "patterns": [
+                {
+                    "name": "keyword.declaration.lsprepost-command-file",
+                    "match": "\\bparameter\\b"
+                },
+                {
+                    "name": "variable.other.lsprepost-command-file",
+                    "match": "(?<=parameter\\s+)\\w+"
+                }
+            ]
+        },
+        "parameter-references": {
+            "patterns": [
+                {
+                    "name": "variable.other.lsprepost-command-file",
+                    "match": "&\\w+"
+                }
+            ]
+        },
+        "statements": {
+            "patterns": [
+                {
+                    "name": "punctuation.terminator.lsprepost-command-file",
+                    "match": ";"
+                }
+            ]
+        }
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "rootDir": "src",
+        "sourceMap": true,
+        "strict": true,
+        "esModuleInterop": true
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
I have added a feature to this VS Code extension that allows users to open files included with the INCLUDE keyword directly from the context menu.
I would be grateful if you could consider merging this.
